### PR TITLE
CMParts: statusbar: Enable notification icon count by default

### DIFF
--- a/res/xml/status_bar_settings.xml
+++ b/res/xml/status_bar_settings.xml
@@ -90,7 +90,7 @@
         android:key="status_bar_notif_count"
         android:title="@string/status_bar_notif_count_title"
         android:summary="@string/status_bar_notif_count_summary"
-        android:defaultValue="false" />
+        android:defaultValue="true" />
 
     <!-- Double tap to sleep -->
     <cyanogenmod.preference.CMSystemSettingSwitchPreference


### PR DESCRIPTION
This used to be enabled by default in previous releases.

Change-Id: I2eedf7d6a7864e8c27f74493af5227b61f7d8f31